### PR TITLE
Add tags to home page notes list view

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -9,6 +9,7 @@
     "exposed-modules": [],
     "dependencies": {
         "NoRedInk/elm-decode-pipeline": "3.0.0 <= v < 4.0.0",
+        "elm-community/string-extra": "1.4.0 <= v < 2.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/http": "1.0.0 <= v < 2.0.0",

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -1,5 +1,6 @@
 module Main exposing (..)
 
+import Array exposing (Array)
 import Css exposing (pct, px)
 import Date exposing (Date, fromString)
 import Html
@@ -326,6 +327,7 @@ docView document docId =
 type alias Document =
     { id : String
     , title : String
+    , tags : Array String
     , html : String
     , created : Date
     , updated : Date
@@ -346,6 +348,7 @@ documentDecoder =
     decode Document
         |> required "id" Json.Decode.string
         |> required "title" Json.Decode.string
+        |> required "tags" (Json.Decode.array Json.Decode.string)
         |> required "html" Json.Decode.string
         |> required "created-at" dateDecoder
         |> required "updated-at" dateDecoder

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -67,7 +67,6 @@ styles =
 type alias Model =
     { apiRoot : String
     , route : Route
-    , tagFilter : Maybe String
     , document : WebData Document
     , notes : WebData (List Document)
     }
@@ -102,11 +101,8 @@ init flags location =
         initialRoute =
             parseLocation location
 
-        initialFilter =
-            Nothing
-
         model =
-            Model flags.apiRoot initialRoute initialFilter initialDocument initialNotes
+            Model flags.apiRoot initialRoute initialDocument initialNotes
 
         cmd =
             getRouteCmd model initialRoute

--- a/src/elm/Routing.elm
+++ b/src/elm/Routing.elm
@@ -5,7 +5,7 @@ import UrlParser exposing (..)
 
 
 type Route
-    = Home
+    = Home (Maybe String)
     | DocumentViewRoute String
     | NotFoundRoute
 
@@ -13,7 +13,7 @@ type Route
 matchers : Parser (Route -> a) a
 matchers =
     oneOf
-        [ map Home (s "notebook")
+        [ map Home (s "notebook" <?> stringParam "tags")
         , map DocumentViewRoute (s "notebook" </> s "doc" </> string)
         ]
 


### PR DESCRIPTION
This adds some very basic tagging to the list view of notes on the front page.
I might in the future want to add something to quickly go back to the unfiltered
view. There's also the question of whether this switching of tags should be handled
within the client, rather than loading a new url.

connects to #17 